### PR TITLE
feat: add shared UI components (Tag, SectionHeading, NameBlock)

### DIFF
--- a/src/components/NameBlock.tsx
+++ b/src/components/NameBlock.tsx
@@ -13,7 +13,6 @@ export default function NameBlock() {
       aria-label="Scroll back to top"
       className="cursor-pointer select-none text-left bg-transparent border-0 p-0 block"
     >
-    </button>
       <div className="text-[17px] font-semibold text-primary tracking-[-0.02em] mb-1">
         Harry Tjahja
       </div>
@@ -29,6 +28,6 @@ export default function NameBlock() {
       >
         BACK TO TOP ↑
       </div>
-    </div>
+    </button>
   );
 }

--- a/src/components/NameBlock.tsx
+++ b/src/components/NameBlock.tsx
@@ -5,12 +5,15 @@ export default function NameBlock() {
   const [hovered, setHovered] = useState(false);
 
   return (
-    <div
+    <button
+      type="button"
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
       onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
-      className="cursor-pointer select-none"
+      aria-label="Scroll back to top"
+      className="cursor-pointer select-none text-left bg-transparent border-0 p-0 block"
     >
+    </button>
       <div className="text-[17px] font-semibold text-primary tracking-[-0.02em] mb-1">
         Harry Tjahja
       </div>

--- a/src/components/NameBlock.tsx
+++ b/src/components/NameBlock.tsx
@@ -1,0 +1,31 @@
+'use client';
+import { useState } from 'react';
+
+export default function NameBlock() {
+  const [hovered, setHovered] = useState(false);
+
+  return (
+    <div
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+      onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
+      className="cursor-pointer select-none"
+    >
+      <div className="text-[17px] font-semibold text-primary tracking-[-0.02em] mb-1">
+        Harry Tjahja
+      </div>
+      <div className="font-mono text-[11px] text-accent tracking-[0.06em]">
+        SOFTWARE ENGINEER
+      </div>
+      <div
+        className="font-mono text-[9px] text-muted tracking-[0.1em] mt-1.5 transition-all duration-200 pointer-events-none"
+        style={{
+          opacity: hovered ? 1 : 0,
+          transform: hovered ? 'translateY(0)' : 'translateY(-4px)',
+        }}
+      >
+        BACK TO TOP ↑
+      </div>
+    </div>
+  );
+}

--- a/src/components/SectionHeading.tsx
+++ b/src/components/SectionHeading.tsx
@@ -1,0 +1,10 @@
+export default function SectionHeading({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex items-center gap-3 mb-8">
+      <span className="font-mono text-[11px] font-medium tracking-[0.12em] uppercase text-accent whitespace-nowrap">
+        {children}
+      </span>
+      <div className="flex-1 h-px bg-border" />
+    </div>
+  );
+}

--- a/src/components/Tag.tsx
+++ b/src/components/Tag.tsx
@@ -1,0 +1,7 @@
+export default function Tag({ label }: { label: string }) {
+  return (
+    <span className="font-mono text-[11px] font-medium tracking-[0.04em] px-2 py-0.5 rounded bg-tag text-tag-text whitespace-nowrap">
+      {label}
+    </span>
+  );
+}


### PR DESCRIPTION
***Summary***                      
                                                                                                                                                                                     
  - Adds Tag — a monospaced pill component for rendering tech stack labels, using the bg-tag / text-tag-text theme tokens                                                            
  - Adds SectionHeading — a section label with a trailing horizontal rule, using text-accent and bg-border tokens
  - Adds NameBlock — a client component for the sidebar that displays name and title, with a "BACK TO TOP ↑" label that fades in on hover and scrolls to top on click                
                                                                                                                                                                                     
  All three components consume Tailwind color aliases from the CSS custom property token system established in the previous PR. Tag and SectionHeading are server components;        
  NameBlock requires 'use client' for hover state and window.scrollTo.                                                                                                               
                                                                                                                                                                                     
***Notes***                                                                                                                                                                              
   
  These components are not yet consumed by page.tsx — they are prerequisites for the upcoming feat/sidebar and page rewrite PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added interactive name/role block component with hover effects
  * Added styled section heading component with visual divider
  * Added tag component for displaying labels

<!-- end of auto-generated comment: release notes by coderabbit.ai -->