### PR TITLE
feat: update data types and refresh portfolio content

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@emotion/styled": "^11.14.1",
     "@mui/material": "^5.18.0",
     "@mui/material-nextjs": "^7.3.6",
-    "next": "16.1.1",
+    "next": "16.2.4",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,10 +22,10 @@ importers:
         version: 5.18.0(@emotion/react@11.14.0(@types/react@18.3.27)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.27)(react@18.3.1))(@types/react@18.3.27)(react@18.3.1))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@mui/material-nextjs':
         specifier: ^7.3.6
-        version: 7.3.6(@emotion/cache@11.14.0)(@emotion/react@11.14.0(@types/react@18.3.27)(react@18.3.1))(@types/react@18.3.27)(next@16.1.1(@babel/core@7.29.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
+        version: 7.3.6(@emotion/cache@11.14.0)(@emotion/react@11.14.0(@types/react@18.3.27)(react@18.3.1))(@types/react@18.3.27)(next@16.2.4(@babel/core@7.29.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
       next:
-        specifier: 16.1.1
-        version: 16.1.1(@babel/core@7.29.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 16.2.4
+        version: 16.2.4(@babel/core@7.29.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -539,56 +539,56 @@ packages:
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
 
-  '@next/env@16.1.1':
-    resolution: {integrity: sha512-3oxyM97Sr2PqiVyMyrZUtrtM3jqqFxOQJVuKclDsgj/L728iZt/GyslkN4NwarledZATCenbk4Offjk1hQmaAA==}
+  '@next/env@16.2.4':
+    resolution: {integrity: sha512-dKkkOzOSwFYe5RX6y26fZgkSpVAlIOJKQHIiydQcrWH6y/97+RceSOAdjZ14Qa3zLduVUy0TXcn+EiM6t4rPgw==}
 
   '@next/eslint-plugin-next@16.2.4':
     resolution: {integrity: sha512-tOX826JJ96gYK/go18sPUgMq9FK1tqxBFfUCEufJb5XIkWFFmpgU7mahJANKGkHs7F41ir3tReJ3Lv5La0RvhA==}
 
-  '@next/swc-darwin-arm64@16.1.1':
-    resolution: {integrity: sha512-JS3m42ifsVSJjSTzh27nW+Igfha3NdBOFScr9C80hHGrWx55pTrVL23RJbqir7k7/15SKlrLHhh/MQzqBBYrQA==}
+  '@next/swc-darwin-arm64@16.2.4':
+    resolution: {integrity: sha512-OXTFFox5EKN1Ym08vfrz+OXxmCcEjT4SFMbNRsWZE99dMqt2Kcusl5MqPXcW232RYkMLQTy0hqgAMEsfEd/l2A==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@next/swc-darwin-x64@16.1.1':
-    resolution: {integrity: sha512-hbyKtrDGUkgkyQi1m1IyD3q4I/3m9ngr+V93z4oKHrPcmxwNL5iMWORvLSGAf2YujL+6HxgVvZuCYZfLfb4bGw==}
+  '@next/swc-darwin-x64@16.2.4':
+    resolution: {integrity: sha512-XhpVnUfmYWvD3YrXu55XdcAkQtOnvaI6wtQa8fuF5fGoKoxIUZ0kWPtcOfqJEWngFF/lOS9l3+O9CcownhiQxQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@next/swc-linux-arm64-gnu@16.1.1':
-    resolution: {integrity: sha512-/fvHet+EYckFvRLQ0jPHJCUI5/B56+2DpI1xDSvi80r/3Ez+Eaa2Yq4tJcRTaB1kqj/HrYKn8Yplm9bNoMJpwQ==}
+  '@next/swc-linux-arm64-gnu@16.2.4':
+    resolution: {integrity: sha512-Mx/tjlNA3G8kg14QvuGAJ4xBwPk1tUHq56JxZ8CXnZwz1Etz714soCEzGQQzVMz4bEnGPowzkV6Xrp6wAkEWOQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
-  '@next/swc-linux-arm64-musl@16.1.1':
-    resolution: {integrity: sha512-MFHrgL4TXNQbBPzkKKur4Fb5ICEJa87HM7fczFs2+HWblM7mMLdco3dvyTI+QmLBU9xgns/EeeINSZD6Ar+oLg==}
+  '@next/swc-linux-arm64-musl@16.2.4':
+    resolution: {integrity: sha512-iVMMp14514u7Nup2umQS03nT/bN9HurK8ufylC3FZNykrwjtx7V1A7+4kvhbDSCeonTVqV3Txnv0Lu+m2oDXNg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
-  '@next/swc-linux-x64-gnu@16.1.1':
-    resolution: {integrity: sha512-20bYDfgOQAPUkkKBnyP9PTuHiJGM7HzNBbuqmD0jiFVZ0aOldz+VnJhbxzjcSabYsnNjMPsE0cyzEudpYxsrUQ==}
+  '@next/swc-linux-x64-gnu@16.2.4':
+    resolution: {integrity: sha512-EZOvm1aQWgnI/N/xcWOlnS3RQBk0VtVav5Zo7n4p0A7UKyTDx047k8opDbXgBpHl4CulRqRfbw3QrX2w5UOXMQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  '@next/swc-linux-x64-musl@16.1.1':
-    resolution: {integrity: sha512-9pRbK3M4asAHQRkwaXwu601oPZHghuSC8IXNENgbBSyImHv/zY4K5udBusgdHkvJ/Tcr96jJwQYOll0qU8+fPA==}
+  '@next/swc-linux-x64-musl@16.2.4':
+    resolution: {integrity: sha512-h9FxsngCm9cTBf71AR4fGznDEDx1hS7+kSEiIRjq5kO1oXWm07DxVGZjCvk0SGx7TSjlUqhI8oOyz7NfwAdPoA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  '@next/swc-win32-arm64-msvc@16.1.1':
-    resolution: {integrity: sha512-bdfQkggaLgnmYrFkSQfsHfOhk/mCYmjnrbRCGgkMcoOBZ4n+TRRSLmT/CU5SATzlBJ9TpioUyBW/vWFXTqQRiA==}
+  '@next/swc-win32-arm64-msvc@16.2.4':
+    resolution: {integrity: sha512-3NdJV5OXMSOeJYijX+bjaLge3mJBlh4ybydbT4GFoB/2hAojWHtMhl3CYlYoMrjPuodp0nzFVi4Tj2+WaMg+Ow==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
-  '@next/swc-win32-x64-msvc@16.1.1':
-    resolution: {integrity: sha512-Ncwbw2WJ57Al5OX0k4chM68DKhEPlrXBaSXDCi2kPi5f4d8b3ejr3RRJGfKBLrn2YJL5ezNS7w2TZLHSti8CMw==}
+  '@next/swc-win32-x64-msvc@16.2.4':
+    resolution: {integrity: sha512-kMVGgsqhO5YTYODD9IPGGhA6iprWidQckK3LmPeW08PIFENRmgfb4MjXHO+p//d+ts2rpjvK5gXWzXSMrPl9cw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -914,10 +914,6 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  baseline-browser-mapping@2.9.11:
-    resolution: {integrity: sha512-Sg0xJUNDU1sJNGdfGWhVHX0kkZ+HWcvmVymJbj6NSgZZmW/8S9Y2HQ5euytnIgakgxN6papOAWiwDo1ctFDcoQ==}
-    hasBin: true
-
   binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
@@ -957,9 +953,6 @@ packages:
   camelcase-css@2.0.1:
     resolution: {integrity: sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==}
     engines: {node: '>= 6'}
-
-  caniuse-lite@1.0.30001761:
-    resolution: {integrity: sha512-JF9ptu1vP2coz98+5051jZ4PwQgd2ni8A+gYSN7EA7dPKIMf0pDlSUxhdmVOaV3/fYK5uWBkgSXJaRLr4+3A6g==}
 
   caniuse-lite@1.0.30001791:
     resolution: {integrity: sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==}
@@ -1664,8 +1657,8 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
-  next@16.1.1:
-    resolution: {integrity: sha512-QI+T7xrxt1pF6SQ/JYFz95ro/mg/1Znk5vBebsWwbpejj1T0A23hO7GYEaVac9QUOT2BIMiuzm0L99ooq7k0/w==}
+  next@16.2.4:
+    resolution: {integrity: sha512-kPvz56wF5frc+FxlHI5qnklCzbq53HTwORaWBGdT0vNoKh1Aya9XC8aPauH4NJxqtzbWsS5mAbctm4cr+EkQ2Q==}
     engines: {node: '>=20.9.0'}
     hasBin: true
     peerDependencies:
@@ -2620,11 +2613,11 @@ snapshots:
 
   '@mui/core-downloads-tracker@5.18.0': {}
 
-  '@mui/material-nextjs@7.3.6(@emotion/cache@11.14.0)(@emotion/react@11.14.0(@types/react@18.3.27)(react@18.3.1))(@types/react@18.3.27)(next@16.1.1(@babel/core@7.29.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)':
+  '@mui/material-nextjs@7.3.6(@emotion/cache@11.14.0)(@emotion/react@11.14.0(@types/react@18.3.27)(react@18.3.1))(@types/react@18.3.27)(next@16.2.4(@babel/core@7.29.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.28.4
       '@emotion/react': 11.14.0(@types/react@18.3.27)(react@18.3.1)
-      next: 16.1.1(@babel/core@7.29.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      next: 16.2.4(@babel/core@7.29.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
     optionalDependencies:
       '@emotion/cache': 11.14.0
@@ -2711,34 +2704,34 @@ snapshots:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
-  '@next/env@16.1.1': {}
+  '@next/env@16.2.4': {}
 
   '@next/eslint-plugin-next@16.2.4':
     dependencies:
       fast-glob: 3.3.1
 
-  '@next/swc-darwin-arm64@16.1.1':
+  '@next/swc-darwin-arm64@16.2.4':
     optional: true
 
-  '@next/swc-darwin-x64@16.1.1':
+  '@next/swc-darwin-x64@16.2.4':
     optional: true
 
-  '@next/swc-linux-arm64-gnu@16.1.1':
+  '@next/swc-linux-arm64-gnu@16.2.4':
     optional: true
 
-  '@next/swc-linux-arm64-musl@16.1.1':
+  '@next/swc-linux-arm64-musl@16.2.4':
     optional: true
 
-  '@next/swc-linux-x64-gnu@16.1.1':
+  '@next/swc-linux-x64-gnu@16.2.4':
     optional: true
 
-  '@next/swc-linux-x64-musl@16.1.1':
+  '@next/swc-linux-x64-musl@16.2.4':
     optional: true
 
-  '@next/swc-win32-arm64-msvc@16.1.1':
+  '@next/swc-win32-arm64-msvc@16.2.4':
     optional: true
 
-  '@next/swc-win32-x64-msvc@16.1.1':
+  '@next/swc-win32-x64-msvc@16.2.4':
     optional: true
 
   '@nodelib/fs.scandir@2.1.5':
@@ -3075,8 +3068,6 @@ snapshots:
 
   baseline-browser-mapping@2.10.24: {}
 
-  baseline-browser-mapping@2.9.11: {}
-
   binary-extensions@2.3.0: {}
 
   brace-expansion@1.1.12:
@@ -3120,8 +3111,6 @@ snapshots:
   callsites@3.1.0: {}
 
   camelcase-css@2.0.1: {}
-
-  caniuse-lite@1.0.30001761: {}
 
   caniuse-lite@1.0.30001791: {}
 
@@ -3966,25 +3955,25 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
-  next@16.1.1(@babel/core@7.29.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  next@16.2.4(@babel/core@7.29.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
-      '@next/env': 16.1.1
+      '@next/env': 16.2.4
       '@swc/helpers': 0.5.15
-      baseline-browser-mapping: 2.9.11
-      caniuse-lite: 1.0.30001761
+      baseline-browser-mapping: 2.10.24
+      caniuse-lite: 1.0.30001791
       postcss: 8.4.31
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       styled-jsx: 5.1.6(@babel/core@7.29.0)(react@18.3.1)
     optionalDependencies:
-      '@next/swc-darwin-arm64': 16.1.1
-      '@next/swc-darwin-x64': 16.1.1
-      '@next/swc-linux-arm64-gnu': 16.1.1
-      '@next/swc-linux-arm64-musl': 16.1.1
-      '@next/swc-linux-x64-gnu': 16.1.1
-      '@next/swc-linux-x64-musl': 16.1.1
-      '@next/swc-win32-arm64-msvc': 16.1.1
-      '@next/swc-win32-x64-msvc': 16.1.1
+      '@next/swc-darwin-arm64': 16.2.4
+      '@next/swc-darwin-x64': 16.2.4
+      '@next/swc-linux-arm64-gnu': 16.2.4
+      '@next/swc-linux-arm64-musl': 16.2.4
+      '@next/swc-linux-x64-gnu': 16.2.4
+      '@next/swc-linux-x64-musl': 16.2.4
+      '@next/swc-win32-arm64-msvc': 16.2.4
+      '@next/swc-win32-x64-msvc': 16.2.4
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -36,7 +36,7 @@ const Home = () => {
               {work.experienceTime}
             </YearLabel>
             <SubheaderCopy variant="h3">
-              {work.companyPosition}
+              {`${work.role} - ${work.company}`}
             </SubheaderCopy>
             <List dense disablePadding>
               {work.positionDescription.map((point, i) => (

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -50,7 +50,7 @@ const Home = () => {
           </ExperienceContainer>
         ))}
       </Stack>
-      <Stack spacing="24px" id="experience">
+      <Stack spacing="24px" id="projects">
         <SubheaderCopy variant="h3" margin="24px 0">
           Projects
         </SubheaderCopy>

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -1,4 +1,4 @@
-import { Project, WorkExperience } from "./types";
+import { Project, SkillCategory, WorkExperience } from "./types";
 
 export const ABOUT_ME = [
   "Software Engineer with 3+ years of experience building web and mobile platforms from system design to production release. Shipped React/TypeScript products used by thousands of users, integrated RESTful APIs into production codebases, and built automated testing pipelines that reduced QA overhead by 30%.",
@@ -53,7 +53,7 @@ export const PROJECT_LIST: Project[] = [
   },
 ];
 
-export const SKILLS_LIST = [
+export const SKILLS_LIST: SkillCategory[] = [
   { category: 'Languages',    items: ['TypeScript', 'JavaScript', 'Python', 'Java', 'C++'] },
   { category: 'Frontend',     items: ['React', 'React Native', 'Next.js', 'Tailwind CSS', 'Redux', 'HTML', 'CSS', 'Material UI'] },
   { category: 'Backend',      items: ['Node.js', 'Express', 'REST APIs', 'CRON Jobs'] },

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -1,76 +1,62 @@
 import { Project, WorkExperience } from "./types";
 
 export const ABOUT_ME = [
-  "I’m a software engineer with over 3 years of experience building web and mobile\
-  applications used by thousands of users. I’m passionate about bringing designs to\
-  life—turning prototypes into intuitive, feature-rich user experiences built for usability.",
-  "My core expertise lies in React and React Native. I’ve contributed to developing scalable\
-  UI components across a variety of projects, including a skincare-focused mobile app with\
-  IoT device integration, a web platform created to break the Guinness World Record for the\
-  largest online photo album of smiling mouths, and a promotional sweepstakes website\
-  supporting a wine company’s marketing campaign.",
-  "I thrive at the intersection of design and development,\
-  and enjoy crafting seamless digital experiences that people love to use."
-]
+  "Software Engineer with 3+ years of experience building web and mobile platforms from system design to production release. Shipped React/TypeScript products used by thousands of users, integrated RESTful APIs into production codebases, and built automated testing pipelines that reduced QA overhead by 30%.",
+  "I approach engineering problems by deeply understanding customer needs, weighing technical tradeoffs, and pushing for the right solution at the right time. I collaborate closely with Product, Design, and Support to resolve ambiguity and ship reliable, maintainable software."
+];
 
 export const EXPERIENCE_LIST: WorkExperience[] = [
   {
-    companyPosition: 'Software Developer - Yeti LLC',
-    experienceTime: '2022 - 2024',
+    company: 'SF Bay Area Builders',
+    role: 'Hackathon Conference Volunteer',
+    experienceTime: 'Jul 2025 – Jan 2026',
     positionDescription: [
-      '- Integrated an internal sprint point tracking system for the company’s app,\
-        integrating JIRA’s API to fetch and store project sprint data in a Render Postgres database.\
-        Automated daily data retrieval with a CRON job and optimized access using Prisma ORM,\
-        ensuring seamless and up-to-date project tracking.',
-      '- Translated responsive designed prototypes into a fully functional web app using React\
-        and Material UI, leveraging Zustand for state management to process and store over 20,000\
-        user-submitted images in Hygraph CMS.',
-      '- Developed an Express backend router to batch process user picture submissions and\
-        update statuses via a REST API endpoint. This feature was integrated with an internal\
-        admin portal, enabling client moderators to approve image submissions 5x faster,\
-        significantly improving moderation efficiency.',
-      '- Integrated multilingual support to a non-profit donation website using Hygraph and Redux,\
-        enabling seamless language rendering. Improved shareability and user experience by\
-        streamlining navigation and centralizing previously dispersed content.'
-    ]
+      'Facilitated check-in for 110+ attendees at a tech-focused monthly conference, ensuring registration and dev environment setup for each hackathon participant.',
+      'Built an LLM-powered Next.js web app with 2 developers, integrating market-analysis APIs to generate investment recommendations from voice input with confidence scores and cited sources.',
+      'Optimized the code review workflow with CodeRabbit AI, streamlining collaboration and earning an award for best use of the platform.',
+    ],
   },
   {
-    companyPosition: 'Junior Software Engineer - Speckle',
-    experienceTime: '2020 - 2021',
+    company: 'Yeti LLC',
+    role: 'Junior Software Developer',
+    experienceTime: 'Mar 2022 – May 2024',
     positionDescription: [
-      '- Worked closely with the designer team and the company founder in an\
-        early-stage startup to develop a cross-platform mobile application for teaching public\
-        speaking skills. Delivered biweekly staging updates to Google Play Store and Apple App\
-        Store with a focus on bug fixes and feature enhancements.',
-      '- Managed a team of 4 internal testers to track user feedback, validate feature functionality,\
-        and ensure alignment with product requirements and the owner’s quality expectations.'
-  ]
+      'Owned end-to-end development of an admin portal that optimized user image moderation by 5× for a non-profit online photo album, driving the platform to 21,274 unique photos and a Guinness World Record.',
+      'Designed an automated sprint point tracking system improving project managers\' workflow efficiency by 50%, connecting JIRA\'s API to a Postgres database via Prisma ORM with daily CRON-based ingestion.',
+      'Developed a React sweepstakes web app for a wine company, attracting 2,000+ new users with customized Material UI components built for reuse across future campaigns.',
+      'Reduced QA overhead by 30% by architecting automated testing pipelines using GitHub Actions, refactoring unit and integration tests in Jest to enforce continuous delivery standards.',
+    ],
+  },
+  {
+    company: 'Speckle Corp',
+    role: 'Associate Front End Software Engineer',
+    experienceTime: 'Aug 2020 – Sep 2021',
+    positionDescription: [
+      'Led requirements gathering and product direction with stakeholders to deliver a cross-platform mobile app for teaching public speaking skills using React Native, shipping biweekly updates to the Google Play Store and Apple App Store.',
+      'Managed a team of 4 internal testers to track user feedback, validate feature functionality, and ensure alignment with product requirements and quality expectations.',
+    ],
   },
 ];
 
 export const PROJECT_LIST: Project[] = [
   {
-    projectName: 'WhyBot AI Mobile App',
-    experienceTime: 'June 2023',
-    projectDescription: 'Collaborated in a hackathon with developers at Yeti to integrrate OpenAI’s\
-     ChatGPT API to create a mobile app that dynamically responds to voice-inputted questions.\
-      Developed an interactive feature enabling users to request simplified explanations or\
-       continuously ask "why," showcasing the LLM model’s ability to condense and refine information.'
+    projectName: 'AI News Curator',
+    experienceTime: 'Aug – Oct 2025',
+    projectDescription: 'A React Native app powered by Google Gemini AI to generate personalized news feeds. Integrated and validated API endpoints via Postman, using the Gemini LLM to rank and surface articles by user preference.',
+    tags: ['React Native', 'Google Gemini', 'Postman', 'REST API'],
   },
   {
     projectName: 'FinPal – Stock Portfolio Financial Advisor',
-    experienceTime: 'August 2025',
-    projectDescription: 'Developed an AI-powered Next.js web app that delivers investment advice\
-     from voice-inputted prompts. Integrated an API that analyzes market data and generates clear\
-      and simple recommendations with confidence scores, rationale, and cited sources.'
+    experienceTime: 'Jul 2025',
+    projectDescription: 'LLM-powered Next.js web app built at a hackathon that delivers investment advice from voice-inputted prompts. Integrated market-analysis APIs to generate clear recommendations with confidence scores, rationale, and cited sources. Awarded best use of CodeRabbit AI.',
+    tags: ['Next.js', 'TypeScript', 'LLM', 'Voice API', 'CodeRabbit AI'],
   },
-  {
-    projectName: 'AI News Curator',
-    experienceTime: 'August 2025 – Present',
-    projectDescription: 'Developed a React Native mobile app utilizing Google Gemini AI \
-    to personalize news curation based on user interests. Evaluated API endpoints with\
-      Postman to assess scalability and use cases, and integrated them to gather articles \
-      from various sources. Applied Gemini LLM to filter fetched articles and deliver the most \
-      relevant articles aligned with user preferences.'
-  }
+];
+
+export const SKILLS_LIST = [
+  { category: 'Languages',    items: ['TypeScript', 'JavaScript', 'Python', 'Java', 'C++'] },
+  { category: 'Frontend',     items: ['React', 'React Native', 'Next.js', 'Tailwind CSS', 'Redux', 'HTML', 'CSS', 'Material UI'] },
+  { category: 'Backend',      items: ['Node.js', 'Express', 'REST APIs', 'CRON Jobs'] },
+  { category: 'Testing & CI', items: ['Jest', 'GitHub Actions', 'CodeRabbit AI'] },
+  { category: 'Tools',        items: ['Git', 'Postman', 'Vercel'] },
 ];

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -11,3 +11,8 @@ export type Project = {
   projectDescription: string;
   tags: string[];
 };
+
+export interface SkillCategory {
+  category: string;
+  items: string[];
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1,11 +1,13 @@
 export type WorkExperience = {
-  companyPosition: string,
-  experienceTime: string,
-  positionDescription: string[],
+  company: string;
+  role: string;
+  experienceTime: string;
+  positionDescription: string[];
 };
 
 export type Project = {
-  projectName: string,
-  experienceTime: string,
-  projectDescription: string,
+  projectName: string;
+  experienceTime: string;
+  projectDescription: string;
+  tags: string[];
 };


### PR DESCRIPTION
***Summary***
  - Updated WorkExperience type: replaced companyPosition with separate company and role fields to support the new sidebar layout where role and company render independently        
  - Added tags: string[] to Project type for tech stack pill display on project cards
  - Replaced all portfolio content in constants.ts with updated copy: condensed ABOUT_ME (2 paragraphs, metrics-forward), 3 experience entries up from 2 (added SF Bay Area          
  Builders), 2 project entries down from 3 (removed WhyBot, added tags to each), and a new SKILLS_LIST export with 5 categorised skill groups                                        
  - Applied a minimal compatibility patch to page.tsx to keep the build green: work.companyPosition replaced with `${work.role} - ${work.company}` until the full page rewrite lands 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Updates**
- Refreshed portfolio information with updated personal descriptions and professional background details
- Redesigned experience section to display role and company as separate distinct fields for improved clarity
- Updated project collection with new projects, each now featuring category tags for better organization and visibility
- Reorganized skills inventory with improved categorical structure and updated technical tool listings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->