### PR TITLE
feat: mobile nav component and responsive experience layout

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -45,3 +45,6 @@
 
 html { scroll-behavior: smooth; }
 *, *::before, *::after { box-sizing: border-box; }
+
+section { scroll-margin-top: 5rem; }
+@media (min-width: 768px) { section { scroll-margin-top: 0; } }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,6 +2,11 @@
 @tailwind components;
 @tailwind utilities;
 
+@layer utilities {
+  .no-scrollbar::-webkit-scrollbar { display: none; }
+  .no-scrollbar { -ms-overflow-style: none; scrollbar-width: none; }
+}
+
 /* ── Light mode (default) ── */
 :root {
   --color-bg:             #f2f7f8;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { cookies } from "next/headers";
 import ThemeProvider from "@/components/ThemeProvider";
 import Sidebar from "@/components/Sidebar";
+import MobileNav from "@/components/MobileNav";
 import "./globals.css";
 
 export const metadata: Metadata = {
@@ -28,6 +29,7 @@ export default async function RootLayout({
         <ThemeProvider defaultDark={defaultDark}>
           <div className="bg-bg min-h-screen text-primary">
             <Sidebar />
+            <MobileNav />
             <main className="md:ml-[220px] px-6 md:px-16 pt-16 max-w-[860px]">
               <div className="flex flex-col gap-[72px]">
                 {children}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -55,8 +55,8 @@ const Home = () => {
         <SectionHeading>Experience</SectionHeading>
         <div className="flex flex-col gap-10">
           {EXPERIENCE_LIST.map((work, i) => (
-            <div key={i} className="grid gap-x-7" style={{ gridTemplateColumns: '100px 1fr' }}>
-              <span className="font-mono text-[11px] text-muted tracking-[0.04em] pt-0.5">
+            <div key={i} className="flex flex-col gap-1 md:grid md:grid-cols-[100px_1fr] md:gap-x-7">
+              <span className="font-mono text-[11px] text-muted tracking-[0.04em] md:pt-0.5">
                 {work.experienceTime}
               </span>
               <div>

--- a/src/components/MobileNav.tsx
+++ b/src/components/MobileNav.tsx
@@ -9,6 +9,7 @@ export default function MobileNav() {
     <header className="md:hidden sticky top-0 z-40 bg-surface border-b border-border px-6 py-3">
       <div className="flex items-center justify-center mb-2">
         <button
+          aria-label="Scroll to top"
           type="button"
           onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
           className="text-[15px] font-semibold text-primary tracking-[-0.02em]"

--- a/src/components/MobileNav.tsx
+++ b/src/components/MobileNav.tsx
@@ -1,28 +1,9 @@
 'use client';
-import { useEffect, useState } from 'react';
 import { NAV_LINKS } from '@/shared/constants';
+import { useActiveSection } from '@/hooks/useActiveSection';
 
 export default function MobileNav() {
-  const [activeId, setActiveId] = useState('');
-
-  useEffect(() => {
-    const observer = new IntersectionObserver(
-      (entries) => {
-        const winner = entries
-          .filter((e) => e.isIntersecting)
-          .sort((a, b) => b.intersectionRatio - a.intersectionRatio)[0];
-        if (winner) setActiveId(winner.target.id);
-      },
-      { rootMargin: '-40% 0px -55% 0px' }
-    );
-
-    NAV_LINKS.forEach(({ href }) => {
-      const el = document.querySelector(href);
-      if (el) observer.observe(el);
-    });
-
-    return () => observer.disconnect();
-  }, []);
+  const activeId = useActiveSection(NAV_LINKS.map(({ href }) => href));
 
   return (
     <header className="md:hidden sticky top-0 z-40 bg-surface border-b border-border px-6 py-3">

--- a/src/components/MobileNav.tsx
+++ b/src/components/MobileNav.tsx
@@ -1,0 +1,59 @@
+'use client';
+import { useEffect, useState } from 'react';
+import { NAV_LINKS } from '@/shared/constants';
+
+export default function MobileNav() {
+  const [activeId, setActiveId] = useState('');
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const winner = entries
+          .filter((e) => e.isIntersecting)
+          .sort((a, b) => b.intersectionRatio - a.intersectionRatio)[0];
+        if (winner) setActiveId(winner.target.id);
+      },
+      { rootMargin: '-40% 0px -55% 0px' }
+    );
+
+    NAV_LINKS.forEach(({ href }) => {
+      const el = document.querySelector(href);
+      if (el) observer.observe(el);
+    });
+
+    return () => observer.disconnect();
+  }, []);
+
+  return (
+    <header className="md:hidden sticky top-0 z-40 bg-surface border-b border-border px-6 py-3">
+      <div className="flex items-center justify-center mb-2">
+        <button
+          type="button"
+          onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
+          className="text-[15px] font-semibold text-primary tracking-[-0.02em]"
+        >
+          Harry Tjahja
+        </button>
+      </div>
+      <nav className="flex gap-1 overflow-x-auto no-scrollbar">
+        {NAV_LINKS.map(({ label, href }) => {
+          const id = href.slice(1);
+          const isActive = activeId === id;
+          return (
+            <a
+              key={href}
+              href={href}
+              className={
+                isActive
+                  ? 'shrink-0 px-2.5 py-1 rounded-md font-mono text-[11px] font-medium text-accent bg-accent-subtle whitespace-nowrap'
+                  : 'shrink-0 px-2.5 py-1 rounded-md font-mono text-[11px] text-secondary hover:text-primary transition-colors whitespace-nowrap'
+              }
+            >
+              {label}
+            </a>
+          );
+        })}
+      </nav>
+    </header>
+  );
+}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,31 +1,12 @@
 'use client';
-import { useEffect, useState } from 'react';
 import NameBlock from './NameBlock';
 import { useTheme } from './ThemeProvider';
 import { NAV_LINKS } from '@/shared/constants';
+import { useActiveSection } from '@/hooks/useActiveSection';
 
 export default function Sidebar() {
-  const [activeId, setActiveId] = useState('');
+  const activeId = useActiveSection(NAV_LINKS.map(({ href }) => href));
   const { dark, toggle } = useTheme();
-
-  useEffect(() => {
-    const observer = new IntersectionObserver(
-      (entries) => {
-        const winner = entries
-          .filter((e) => e.isIntersecting)
-          .sort((a, b) => b.intersectionRatio - a.intersectionRatio)[0];
-        if (winner) setActiveId(winner.target.id);
-      },
-      { rootMargin: '-40% 0px -55% 0px' }
-    );
-
-    NAV_LINKS.forEach(({ href }) => {
-      const el = document.querySelector(href);
-      if (el) observer.observe(el);
-    });
-
-    return () => observer.disconnect();
-  }, []);
 
   return (
     <>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -2,14 +2,7 @@
 import { useEffect, useState } from 'react';
 import NameBlock from './NameBlock';
 import { useTheme } from './ThemeProvider';
-
-const NAV_LINKS = [
-  { label: 'About',      href: '#about' },
-  { label: 'Experience', href: '#experience' },
-  { label: 'Projects',   href: '#projects' },
-  { label: 'Skills',     href: '#skills' },
-  { label: 'Contact',    href: '#contact' },
-];
+import { NAV_LINKS } from '@/shared/constants';
 
 export default function Sidebar() {
   const [activeId, setActiveId] = useState('');

--- a/src/hooks/useActiveSection.ts
+++ b/src/hooks/useActiveSection.ts
@@ -1,0 +1,26 @@
+import { useEffect, useState } from 'react';
+
+export function useActiveSection(selectors: string[]): string {
+  const [activeId, setActiveId] = useState('');
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const winner = entries
+          .filter((e) => e.isIntersecting)
+          .sort((a, b) => b.intersectionRatio - a.intersectionRatio)[0];
+        if (winner) setActiveId(winner.target.id);
+      },
+      { rootMargin: '-40% 0px -55% 0px' }
+    );
+
+    selectors.forEach((selector) => {
+      const el = document.querySelector(selector);
+      if (el) observer.observe(el);
+    });
+
+    return () => observer.disconnect();
+  }, []);
+
+  return activeId;
+}

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -2,6 +2,14 @@ import { Project, SkillCategory, WorkExperience } from "./types";
 
 export const COOKIE_MAX_AGE = 60 * 60 * 24 * 365; // 1 year
 
+export const NAV_LINKS = [
+  { label: 'About',      href: '#about' },
+  { label: 'Experience', href: '#experience' },
+  { label: 'Projects',   href: '#projects' },
+  { label: 'Skills',     href: '#skills' },
+  { label: 'Contact',    href: '#contact' },
+];
+
 
 export const ABOUT_ME = [
   "Software Engineer with 3+ years of experience building web and mobile platforms from system design to production release. Shipped React/TypeScript products used by thousands of users, integrated RESTful APIs into production codebases, and built automated testing pipelines that reduced QA overhead by 30%.",


### PR DESCRIPTION
***Summary***

  - Creates src/components/MobileNav.tsx — a md:hidden sticky top bar with a centered name button (scroll-to-top) and a horizontally scrollable nav row; uses the same
  IntersectionObserver active-state logic as the sidebar
  - Wires <MobileNav /> into layout.tsx above <main> so it renders on every page
  - Moves NAV_LINKS from Sidebar.tsx into src/shared/constants.ts so both Sidebar and MobileNav share a single source of truth for nav items
  - Fixes the Experience section grid in page.tsx — replaces the inline style (which can't take responsive breakpoints) with flex flex-col on mobile and md:grid
  md:grid-cols-[100px_1fr] on desktop so the date stacks above the content on narrow screens
  - Adds no-scrollbar utility to globals.css so the mobile nav row can scroll horizontally without showing a browser scrollbar

***Notes***

  - NAV_LINKS in constants.ts does not include an Intro link — the mobile nav matches the sidebar's five-link set (About through Contact); the name button serves as the Intro/top
  anchor
  - The mobile dark mode toggle (fixed bottom-right pill added in a prior PR) remains in Sidebar.tsx and is unaffected by this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added mobile navigation with automatic section tracking and sticky header
  * Added `.no-scrollbar` utility for custom scrollbar styling

* **Refactor**
  * Updated Experience section layout with responsive grid utilities
  * Extracted navigation links to a shared constant for reusability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->