### PR TITLE
feat: scale sidebar for large screens

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -30,7 +30,7 @@ export default async function RootLayout({
           <div className="bg-bg min-h-screen text-primary">
             <Sidebar />
             <MobileNav />
-            <main className="md:ml-[220px] 3xl:ml-[320px] px-6 md:px-16 3xl:px-24 pt-16 max-w-[860px] 3xl:max-w-[1100px]">
+            <main className="md:ml-[220px] xl:ml-[320px] px-6 md:px-16 3xl:px-24 pt-16 max-w-[860px] 3xl:max-w-[1100px]">
               <div className="flex flex-col gap-[72px]">
                 {children}
               </div>

--- a/src/components/NameBlock.tsx
+++ b/src/components/NameBlock.tsx
@@ -13,14 +13,14 @@ export default function NameBlock() {
       aria-label="Scroll back to top"
       className="cursor-pointer select-none text-left bg-transparent border-0 p-0 block"
     >
-      <div className="text-[17px] xl:text-[24px] font-semibold text-primary tracking-[-0.02em] mb-1">
+      <div className="text-[17px] xl:text-[30px] font-semibold text-primary tracking-[-0.02em] mb-1">
         Harry Tjahja
       </div>
-      <div className="font-mono text-[11px] xl:text-[15px] text-accent tracking-[0.06em]">
+      <div className="font-mono text-[11px] xl:text-[18px] text-accent tracking-[0.06em]">
         SOFTWARE ENGINEER
       </div>
       <div
-        className="font-mono text-[9px] xl:text-[12px] text-muted tracking-[0.1em] mt-1.5 transition-all duration-200 pointer-events-none"
+        className="font-mono text-[9px] xl:text-[14px] text-muted tracking-[0.1em] mt-1.5 transition-all duration-200 pointer-events-none"
         style={{
           opacity: hovered ? 1 : 0,
           transform: hovered ? 'translateY(0)' : 'translateY(-4px)',

--- a/src/components/NameBlock.tsx
+++ b/src/components/NameBlock.tsx
@@ -13,14 +13,14 @@ export default function NameBlock() {
       aria-label="Scroll back to top"
       className="cursor-pointer select-none text-left bg-transparent border-0 p-0 block"
     >
-      <div className="text-[17px] font-semibold text-primary tracking-[-0.02em] mb-1">
+      <div className="text-[17px] xl:text-[24px] font-semibold text-primary tracking-[-0.02em] mb-1">
         Harry Tjahja
       </div>
-      <div className="font-mono text-[11px] text-accent tracking-[0.06em]">
+      <div className="font-mono text-[11px] xl:text-[15px] text-accent tracking-[0.06em]">
         SOFTWARE ENGINEER
       </div>
       <div
-        className="font-mono text-[9px] text-muted tracking-[0.1em] mt-1.5 transition-all duration-200 pointer-events-none"
+        className="font-mono text-[9px] xl:text-[12px] text-muted tracking-[0.1em] mt-1.5 transition-all duration-200 pointer-events-none"
         style={{
           opacity: hovered ? 1 : 0,
           transform: hovered ? 'translateY(0)' : 'translateY(-4px)',

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -23,17 +23,10 @@ export default function Sidebar() {
               href={href}
               className={
                 isActive
-                  ? 'flex items-center gap-2.5 px-2.5 py-2 xl:px-3 xl:py-2.5 rounded-md text-[13px] xl:text-[18px] font-medium text-accent bg-accent-subtle'
-                  : 'flex items-center gap-2.5 px-2.5 py-2 xl:px-3 xl:py-2.5 rounded-md text-[13px] xl:text-[18px] text-secondary hover:text-primary transition-colors'
+                  ? 'flex items-center px-2.5 py-2 xl:px-3 xl:py-2.5 rounded-md text-[13px] xl:text-[18px] font-medium text-accent bg-accent-subtle'
+                  : 'flex items-center px-2.5 py-2 xl:px-3 xl:py-2.5 rounded-md text-[13px] xl:text-[18px] text-secondary hover:text-primary transition-colors'
               }
             >
-              <span
-                className={
-                  isActive
-                    ? 'w-1 h-1 xl:w-1.5 xl:h-1.5 rounded-full bg-dot shrink-0'
-                    : 'w-1 h-1 xl:w-1.5 xl:h-1.5 rounded-full border border-border shrink-0'
-                }
-              />
               {label}
             </a>
           );

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -10,10 +10,10 @@ export default function Sidebar() {
 
   return (
     <>
-    <aside className="hidden md:flex fixed left-0 top-0 w-[220px] h-screen overflow-y-auto z-50 bg-surface border-r border-border flex-col px-7 py-10">
+    <aside className="hidden md:flex fixed left-0 top-0 w-[220px] xl:w-[320px] h-screen overflow-y-auto z-50 bg-surface border-r border-border flex-col px-7 py-10 xl:px-10 xl:py-14">
       <NameBlock />
 
-      <nav className="flex-1 mt-10 flex flex-col gap-1">
+      <nav className="flex-1 mt-10 flex flex-col gap-1 xl:gap-2">
         {NAV_LINKS.map(({ label, href }) => {
           const id = href.slice(1);
           const isActive = activeId === id;
@@ -23,15 +23,15 @@ export default function Sidebar() {
               href={href}
               className={
                 isActive
-                  ? 'flex items-center gap-2.5 px-2.5 py-2 rounded-md text-[13px] font-medium text-accent bg-accent-subtle'
-                  : 'flex items-center gap-2.5 px-2.5 py-2 rounded-md text-[13px] text-secondary hover:text-primary transition-colors'
+                  ? 'flex items-center gap-2.5 px-2.5 py-2 xl:px-3 xl:py-2.5 rounded-md text-[13px] xl:text-[18px] font-medium text-accent bg-accent-subtle'
+                  : 'flex items-center gap-2.5 px-2.5 py-2 xl:px-3 xl:py-2.5 rounded-md text-[13px] xl:text-[18px] text-secondary hover:text-primary transition-colors'
               }
             >
               <span
                 className={
                   isActive
-                    ? 'w-1 h-1 rounded-full bg-dot shrink-0'
-                    : 'w-1 h-1 rounded-full border border-border shrink-0'
+                    ? 'w-1 h-1 xl:w-1.5 xl:h-1.5 rounded-full bg-dot shrink-0'
+                    : 'w-1 h-1 xl:w-1.5 xl:h-1.5 rounded-full border border-border shrink-0'
                 }
               />
               {label}
@@ -40,19 +40,19 @@ export default function Sidebar() {
         })}
       </nav>
 
-      <div className="flex flex-col gap-3">
-        <div className="flex gap-3">
+      <div className="flex flex-col gap-3 xl:gap-4">
+        <div className="flex gap-3 xl:gap-4">
           <a
             href="https://www.linkedin.com/in/harrytjahja"
             target="_blank"
             rel="noopener noreferrer"
-            className="font-mono text-[11px] text-muted tracking-[0.06em] hover:text-accent transition-colors"
+            className="font-mono text-[11px] xl:text-[14px] text-muted tracking-[0.06em] hover:text-accent transition-colors"
           >
             LinkedIn
           </a>
           <a
             href="mailto:hdtjahja@gmail.com"
-            className="font-mono text-[11px] text-muted tracking-[0.06em] hover:text-accent transition-colors"
+            className="font-mono text-[11px] xl:text-[14px] text-muted tracking-[0.06em] hover:text-accent transition-colors"
           >
             Email
           </a>
@@ -60,9 +60,9 @@ export default function Sidebar() {
         <button
           type="button"
           onClick={toggle}
-          className="font-mono text-[11px] text-muted tracking-[0.06em] flex items-center gap-1.5 hover:text-accent transition-colors"
+          className="font-mono text-[11px] xl:text-[14px] text-muted tracking-[0.06em] flex items-center gap-1.5 hover:text-accent transition-colors"
         >
-          <span className="text-[13px]">{dark ? '☀' : '◑'}</span>
+          <span className="text-[13px] xl:text-[16px]">{dark ? '☀' : '◑'}</span>
           {dark ? 'LIGHT' : 'DARK'}
         </button>
       </div>


### PR DESCRIPTION
## Summary

- Widened sidebar from `220px` to `320px` at the `xl` breakpoint (`1280px+`) with matching padding increases (`xl:px-10 xl:py-14`)
- Scaled all sidebar font sizes at `xl`: nav links `13px` → `18px`, social/toggle links `11px` → `14px`, dark mode icon `13px` → `16px`
- Enlarged NameBlock at `xl`: name `17px` → `30px`, subtitle `11px` → `18px`, "Back to Top" hint `9px` → `14px`
- Removed nav link bullet dot indicators for a cleaner look at all screen sizes
- Updated main content left offset in `layout.tsx` from `3xl:ml-[320px]` → `xl:ml-[320px]` to stay in sync with the wider sidebar

## Notes

- Targets `feat/xl-content-resize` as the base branch — the `3xl` breakpoint and all page content font scaling are defined there
- The `xl:ml-[320px]` offset in `layout.tsx` is the only change outside of sidebar components; it was already stubbed in the base branch as `3xl:ml-[320px]` and is updated here to match the `xl` trigger used by the sidebar


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved layout and spacing for extra-large screen displays
  * Refined navigation styling with updated active state indicators
  * Enhanced typography scaling for better readability on larger screens

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Harry823/harrytjahja-website/pull/15?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->