### PR TITLE
fix: replace inline styles with Tailwind utilities in H1 and NameBlock

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -13,8 +13,7 @@ const Home = () => {
           Available for new opportunities
         </p>
         <h1
-          className="font-semibold text-primary tracking-[-0.03em] leading-[1.1] mb-5"
-          style={{ fontSize: 'clamp(40px, 5vw, 90px)' }}
+          className="text-[clamp(40px,5vw,90px)] font-semibold text-primary tracking-[-0.03em] leading-[1.1] mb-5"
         >
           Harry Tjahja
         </h1>

--- a/src/components/NameBlock.tsx
+++ b/src/components/NameBlock.tsx
@@ -1,17 +1,12 @@
 'use client';
-import { useState } from 'react';
 
 export default function NameBlock() {
-  const [hovered, setHovered] = useState(false);
-
   return (
     <button
       type="button"
-      onMouseEnter={() => setHovered(true)}
-      onMouseLeave={() => setHovered(false)}
       onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
       aria-label="Scroll back to top"
-      className="cursor-pointer select-none text-left bg-transparent border-0 p-0 block"
+      className="group cursor-pointer select-none text-left bg-transparent border-0 p-0 block"
     >
       <div className="text-[17px] xl:text-[30px] font-semibold text-primary tracking-[-0.02em] mb-1">
         Harry Tjahja
@@ -19,13 +14,7 @@ export default function NameBlock() {
       <div className="font-mono text-[11px] xl:text-[18px] text-accent tracking-[0.06em]">
         SOFTWARE ENGINEER
       </div>
-      <div
-        className="font-mono text-[9px] xl:text-[14px] text-muted tracking-[0.1em] mt-1.5 transition-all duration-200 pointer-events-none"
-        style={{
-          opacity: hovered ? 1 : 0,
-          transform: hovered ? 'translateY(0)' : 'translateY(-4px)',
-        }}
-      >
+      <div className="font-mono text-[9px] xl:text-[14px] text-muted tracking-[0.1em] mt-1.5 transition-all duration-200 pointer-events-none opacity-0 -translate-y-1 group-hover:opacity-100 group-hover:translate-y-0">
         BACK TO TOP ↑
       </div>
     </button>


### PR DESCRIPTION
## Summary

- **`page.tsx`**: Removed `style={{ fontSize: 'clamp(40px, 5vw, 90px)' }}` from the hero H1 and moved the value into `className` as a Tailwind arbitrary value (`text-[clamp(40px,5vw,90px)]`). Keeps the same fluid sizing behaviour with no inline style prop.
- **`NameBlock.tsx`**: Replaced JS-driven hover state (`useState`, `onMouseEnter`, `onMouseLeave`) and inline `style` object (`opacity`, `transform`) with Tailwind's `group` / `group-hover` pattern. The "BACK TO TOP ↑" hint now fades and slides via CSS alone — no React re-render on hover.

## Notes

- Behaviour is identical to before; only the implementation mechanism changed.
- `'use client'` is retained in `NameBlock.tsx` because `window.scrollTo` still requires a client component.